### PR TITLE
Fix initial window location for large window

### DIFF
--- a/pentevo/unreal/Unreal/dx.cpp
+++ b/pentevo/unreal/Unreal/dx.cpp
@@ -1412,8 +1412,9 @@ static void CalcWindowSize()
         temp.rflags |= drivers[conf.driver].flags;
 
     // select resolution
-    temp.ox = temp.scx = 448;
-    temp.oy = temp.scy = 320;
+    temp.ox = temp.scx = bordersizes[conf.bordersize].xsize;
+    temp.oy = temp.scy = bordersizes[conf.bordersize].ysize;
+
 
     if (temp.rflags & RF_2X)
     {
@@ -1456,6 +1457,8 @@ void start_dx()
    cy = Client.bottom - Client.top;
    int winx = rect1.left + (rect1.right - rect1.left - cx) / 2;
    int winy = rect1.top + (rect1.bottom - rect1.top - cy) / 2;
+   winx = winx < 0 ? 0 : winx;
+   winy = winy < 0 ? 0 : winy;
 
    main_menu = LoadMenu(hIn, MAKEINTRESOURCE(IDR_MAINMENU));
    wnd = CreateWindow("EMUL_WND", "UnrealSpeccy", WS_VISIBLE|WS_OVERLAPPEDWINDOW,


### PR DESCRIPTION
Фикшу редкостную штуку:
1. В конфиге Border = 2, video=quad (пробовал на конфиге пентагона)
2. Основной монитор имеет разрешение по Y=1080
При старте Y окна эмулятора отрицательный, окно обрезано верхней границей экрана, заголовка не видно. Хотя потом окно ресайзится и видно, что оно в экран влезает по высоте.

Надо бы сделать 2 вещи:
1.
В dx.cpp, start_dx() после winx=, winy= (строка 1459, центровка) написать
winx = winx < 0 ? 0 : winx;
winy = winy < 0 ? 0 : winy;
чтобы заголовок был на экране даже если окно эмулятора не влезает в него.

2. В dx.cpp, CalcWindowSize() строки 1415 и 1416 заменить на
temp.ox = temp.scx = bordersizes[conf.bordersize].xsize;
temp.oy = temp.scy = bordersizes[conf.bordersize].ysize;
чтобы при создании окна использовался не прибитый молотком размер экрана 448x320, а тот, что задан в конфиге.